### PR TITLE
Fix: handle z levels not being spaced 1 apart in PR #7654

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -1345,8 +1345,6 @@ void T2DMap::paintEvent(QPaintEvent* e)
         showRoomNames = (mapNameFont.pointSizeF() > 3.0);
     }
 
-    const int zLevel = mMapCenterZ;
-
     const float exitWidth = 1 / eSize * mRoomWidth * rSize;
 
     painter.fillRect(0, 0, width(), height(), mpHost->mBgColor_2);
@@ -1418,70 +1416,89 @@ void T2DMap::paintEvent(QPaintEvent* e)
     QSetIterator<int> itRoom(pDrawnArea->getAreaRooms());
 
     if (mudlet::self()->mDrawUpperLowerLevels) {
-        // draw room on lower z-levels
-        while (itRoom.hasNext()) {
-            const int currentAreaRoom = itRoom.next();
-            TRoom* room = mpMap->mpRoomDB->getRoom(currentAreaRoom);
-            if (!room) {
-                continue;
-            }
-
-            if (room->z() == zLevel - 1) {
-                const float rx = room->x() * mRoomWidth + static_cast<float>(mRX);
-                const float ry = room->y() * -1 * mRoomHeight + static_cast<float>(mRY);
-                if (rx >= 0 && ry >= 0 && rx <= widgetWidth && ry <= widgetHeight) {
-                    painter.save();
-                    painter.setPen(Qt::NoPen);
-                    painter.setBrush(mpHost->mLowerLevelColor);
-                    if (mBubbleMode) {
-                        const float roomRadius = 0.5 * rSize * mRoomWidth;
-                        const QPointF roomCenter = QPointF(rx - (roomRadius * rSize * 0.5), ry + (roomRadius * rSize * 0.5));
-                        QPainterPath diameterPath;
-                        diameterPath.addEllipse(roomCenter, roomRadius, roomRadius);
-                        painter.drawPath(diameterPath);
-                    } else {
-                        painter.drawRect(rx - (mRoomWidth * rSize * 0.8), ry - (mRoomHeight * rSize * 0.2), mRoomWidth * rSize, mRoomHeight * rSize);
-                    }
-                painter.restore();
+        // Determine the adjacent level above and below the current mMapCenterZ
+        std::optional<int> zLevelBelow;
+        std::optional<int> zLevelAbove;
+        for (int i = 0, total = pDrawnArea->zLevels.count(); i < total; ++i) {
+            if (pDrawnArea->zLevels.at(i) == mMapCenterZ) {
+                if (i+1 < total) {
+                    zLevelAbove = pDrawnArea->zLevels.at(i+1);
                 }
+                if (i > 0) {
+                    zLevelBelow = pDrawnArea->zLevels.at(i-1);
+                }
+                break;
             }
         }
-        itRoom.toFront();
 
-        // draw rooms on upper z-levels
-        while (itRoom.hasNext()) {
-            const int currentAreaRoom = itRoom.next();
-            TRoom* room = mpMap->mpRoomDB->getRoom(currentAreaRoom);
-            if (!room) {
-                continue;
-            }
+        if (zLevelBelow.has_value()) {
+            // draw room on lower z-levels
+            while (itRoom.hasNext()) {
+                const int currentAreaRoom = itRoom.next();
+                TRoom* room = mpMap->mpRoomDB->getRoom(currentAreaRoom);
+                if (!room) {
+                    continue;
+                }
 
-            if (room->z() == zLevel + 1) {
-                const float rx = room->x() * mRoomWidth + static_cast<float>(mRX);
-                const float ry = room->y() * -1 * mRoomHeight + static_cast<float>(mRY);
-                if (rx >= 0 && ry >= 0 && rx <= widgetWidth && ry <= widgetHeight) {
-                    painter.save();
-                    painter.setPen(QPen(mpHost->mUpperLevelColor, 1));
-                    painter.setBrush(Qt::transparent);
-                    if (mBubbleMode) {
-                        const float roomRadius = 0.5 * rSize * mRoomWidth;
-                        const QPointF roomCenter = QPointF(rx + (roomRadius * rSize * 0.5), ry - (roomRadius * rSize * 0.5));
-                        QPainterPath diameterPath;
-                        diameterPath.addEllipse(roomCenter, roomRadius, roomRadius);
-                        painter.drawPath(diameterPath);
-                    } else {
-                        painter.drawRect(rx - (mRoomWidth * rSize * 0.2), ry - (mRoomHeight * rSize * 0.8), mRoomWidth * rSize, mRoomHeight * rSize);
-                    }
+                if (room->z() == zLevelBelow.value()) {
+                    const float rx = room->x() * mRoomWidth + static_cast<float>(mRX);
+                    const float ry = room->y() * -1 * mRoomHeight + static_cast<float>(mRY);
+                    if (rx >= 0 && ry >= 0 && rx <= widgetWidth && ry <= widgetHeight) {
+                        painter.save();
+                        painter.setPen(Qt::NoPen);
+                        painter.setBrush(mpHost->mLowerLevelColor);
+                        if (mBubbleMode) {
+                            const float roomRadius = 0.5 * rSize * mRoomWidth;
+                            const QPointF roomCenter = QPointF(rx - (roomRadius * rSize * 0.5), ry + (roomRadius * rSize * 0.5));
+                            QPainterPath diameterPath;
+                            diameterPath.addEllipse(roomCenter, roomRadius, roomRadius);
+                            painter.drawPath(diameterPath);
+                        } else {
+                            painter.drawRect(rx - (mRoomWidth * rSize * 0.8), ry - (mRoomHeight * rSize * 0.2), mRoomWidth * rSize, mRoomHeight * rSize);
+                        }
                     painter.restore();
+                    }
                 }
             }
+            itRoom.toFront();
         }
-        itRoom.toFront();
+
+        if (zLevelAbove.has_value()) {
+            // draw rooms on upper z-levels
+            while (itRoom.hasNext()) {
+                const int currentAreaRoom = itRoom.next();
+                TRoom* room = mpMap->mpRoomDB->getRoom(currentAreaRoom);
+                if (!room) {
+                    continue;
+                }
+
+                if (room->z() == mMapCenterZ + 1) {
+                    const float rx = room->x() * mRoomWidth + static_cast<float>(mRX);
+                    const float ry = room->y() * -1 * mRoomHeight + static_cast<float>(mRY);
+                    if (rx >= 0 && ry >= 0 && rx <= widgetWidth && ry <= widgetHeight) {
+                        painter.save();
+                        painter.setPen(QPen(mpHost->mUpperLevelColor, 1));
+                        painter.setBrush(Qt::transparent);
+                        if (mBubbleMode) {
+                            const float roomRadius = 0.5 * rSize * mRoomWidth;
+                            const QPointF roomCenter = QPointF(rx + (roomRadius * rSize * 0.5), ry - (roomRadius * rSize * 0.5));
+                            QPainterPath diameterPath;
+                            diameterPath.addEllipse(roomCenter, roomRadius, roomRadius);
+                            painter.drawPath(diameterPath);
+                        } else {
+                            painter.drawRect(rx - (mRoomWidth * rSize * 0.2), ry - (mRoomHeight * rSize * 0.8), mRoomWidth * rSize, mRoomHeight * rSize);
+                        }
+                        painter.restore();
+                    }
+                }
+            }
+            itRoom.toFront();
+        }
     }
 
     // draw room exits
     if (!pDrawnArea->gridMode) {
-        paintRoomExits(painter, pen, exitList, oneWayExits, pDrawnArea, zLevel, exitWidth, areaExitsMap);
+        paintRoomExits(painter, pen, exitList, oneWayExits, pDrawnArea, exitWidth, areaExitsMap);
     }
 
     // now draw rooms on selected z-level
@@ -1492,7 +1509,7 @@ void T2DMap::paintEvent(QPaintEvent* e)
             continue;
         }
 
-        if (room->z() != zLevel) {
+        if (room->z() != mMapCenterZ) {
             continue;
         }
 
@@ -1757,7 +1774,7 @@ void T2DMap::drawDoor(QPainter& painter, const TRoom& room, const QString& dirKe
     painter.restore();
 }
 
-void T2DMap::paintRoomExits(QPainter& painter, QPen& pen, QList<int>& exitList, QList<int>& oneWayExits, const TArea* pArea, int zLevel, float exitWidth, QMap<int, QPointF>& areaExitsMap)
+void T2DMap::paintRoomExits(QPainter& painter, QPen& pen, QList<int>& exitList, QList<int>& oneWayExits, const TArea* pArea, float exitWidth, QMap<int, QPointF>& areaExitsMap)
 {
     const float exitArrowScale = (mLargeAreaExitArrows ? 2.0f : 1.0f);
     const float widgetWidth = width();
@@ -1809,7 +1826,7 @@ void T2DMap::paintRoomExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
         const float ry = room->y() * -1 * mRoomHeight + mRY;
         const int rz = room->z();
 
-        if (rz != zLevel) {
+        if (rz != mMapCenterZ) {
             continue;
         }
 

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -257,7 +257,7 @@ private:
     inline void drawRoom(QPainter&, QFont&, QFont&, QPen&, TRoom*, const bool isGridMode, const bool areRoomIdsLegible, const bool showRoomNames, const int, const float, const float, const QMap<int, QPointF>&, const bool showRoomCollision);
     void paintMapInfo(const QElapsedTimer& renderTimer, QPainter& painter, const int displayAreaId, QColor& infoColor);
     int paintMapInfoContributor(QPainter&, int xOffset, int yOffset, const MapInfoProperties& properties);
-    void paintRoomExits(QPainter&, QPen&, QList<int>& exitList, QList<int>& oneWayExits, const TArea*, int, float, QMap<int, QPointF>&);
+    void paintRoomExits(QPainter&, QPen&, QList<int>& exitList, QList<int>& oneWayExits, const TArea*, float, QMap<int, QPointF>&);
     void initiateSpeedWalk(const int speedWalkStartRoomId, const int speedWalkTargetRoomId);
     inline void drawDoor(QPainter&, const TRoom&, const QString&, const QLineF&);
     void updateMapLabel(QRectF labelRectangle, int labelId, TArea* pArea);

--- a/src/TArea.cpp
+++ b/src/TArea.cpp
@@ -376,7 +376,7 @@ void TArea::calcSpan()
     yminForZ.clear();
     xmaxForZ.clear();
     ymaxForZ.clear();
-    zLevels.clear();
+    QSet<int> zLevelSet;
 
     bool isFirstDone = false;
     QSetIterator<int> itRoom(rooms);
@@ -395,7 +395,7 @@ void TArea::calcSpan()
             max_y = min_y;
             min_z = pR->z();
             max_z = min_z;
-            zLevels.push_back(pR->z());
+            zLevelSet.insert(pR->z());
             xminForZ.insert(pR->z(), pR->x());
             xmaxForZ.insert(pR->z(), pR->x());
             yminForZ.insert(pR->z(), pR->y());
@@ -405,9 +405,7 @@ void TArea::calcSpan()
         } else {
             // Already had one valid room so now must check more things
 
-            if (!zLevels.contains(pR->z())) {
-                zLevels.push_back(pR->z());
-            }
+            zLevelSet.insert(pR->z());
 
             if (!xminForZ.contains(pR->z())) {
                 xminForZ.insert(pR->z(), pR->x());
@@ -459,8 +457,15 @@ void TArea::calcSpan()
         }
     }
 
-    if (zLevels.size() > 1) {
-        // Not essential but it makes debugging a bit clearer if they are sorted
+    const auto setSize = zLevelSet.size();
+    if (!setSize) {
+        zLevels.clear();
+        return;
+    }
+
+    zLevels = QList<int>{zLevelSet.cbegin(), zLevelSet.cend()};
+    if (setSize > 1) {
+        // We now need to it be sorted.
         // The {x|y}{min|max}ForZ are, by definition!
         std::sort(zLevels.begin(), zLevels.end());
     }


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Analyses the used z-levels and uses the ones either side of the current level as the ones to check when determining which rooms to draw in the "above" and "below" modes.

#### Motivation for adding to Mudlet
Not all maps are drawn with a unity (1) space between adjacent levels - indeed if they intend to make use of the route finding code built into Mudlet then the spacing between the z-coordinates need to match those used for the other two coordinates otherwise the A* algorithm's use of the *Manhatten-distance* to determine the closeness of a particular vertex from the target will be miscalculated.

This code will also speed things up slightly when at the top or bottom of the levels - or if the area in the map only has one level - by skipping the attempt to draw the above or below rooms altogether!

#### Other info (issues closed, discussion etc)
Also remove an unneeded local automatic as it duplicates a class member.

